### PR TITLE
Update main.go

### DIFF
--- a/cmd/expressify/main.go
+++ b/cmd/expressify/main.go
@@ -3,33 +3,37 @@ package main
 import (
 	"fmt"
 	"os"
-
-	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/bubbletea"
 	"github.com/codersgyan/expressify/internal/cli_model"
+	"github.com/codersgyan/expressify/internal/structure" // Ensure this package is imported for CopyDir
 )
 
 func main() {
 
-	// cwd, err := os.Getwd()
-	// if err != nil {
-	// 	fmt.Printf("unable to get current working directory: %w", err)
-	// 	os.Exit(1)
-	// }
-	// srcPath := cwd + "/.templates/jsbase"
-	// dstPath := cwd + "/.expressify/auth-service"
+	// Get current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Unable to get current working directory: %v\n", err)
+		os.Exit(1)
+	}
 
-	// cpErr := structure.CopyDir(srcPath, dstPath)
-	// if cpErr != nil {
-	// 	fmt.Printf("Error copying directory: %s\n", cpErr)
-	// } else {
-	// 	fmt.Println("Directory copied successfully.")
-	// }
-	// return n
+	// Define source and destination paths for the directory copy
+	srcPath := cwd + "/.templates/jsbase"
+	dstPath := cwd + "/.expressify/auth-service"
 
+	// Copy the directory
+	cpErr := structure.CopyDir(srcPath, dstPath)
+	if cpErr != nil {
+		fmt.Printf("Error copying directory: %s\n", cpErr)
+		os.Exit(1)
+	} else {
+		fmt.Println("Directory copied successfully.")
+	}
+
+	// Run the CLI program using bubbletea
 	p := tea.NewProgram(cli_model.InitialModel())
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Alas, there's been an error: %v", err)
 		os.Exit(1)
 	}
-
 }


### PR DESCRIPTION
## Issue No. #12 

#### Summary:
This PR addresses the issue by uncommenting the directory copy logic and adding proper error handling. The program now correctly copies the directory from the source path to the destination path and runs the CLI application using the BubbleTea package.

#### Changes:
- **Directory Copying**: Re-enabled the code to copy a directory from the source path (`.templates/jsbase`) to the destination path (`.expressify/auth-service`).
- **Error Handling**: Improved error handling for `os.Getwd()` to ensure that the current working directory is retrieved successfully. If there is an error, a message is displayed and the program exits.
- **Code Cleanup**: Cleaned up commented-out code and unnecessary comments to make the code more readable and functional.
- **Imports**: Ensured the `structure` package (which contains the `CopyDir` function) is imported for the directory copy operation.

#### Issues Resolved:
- Resolved the issue where the directory copying functionality was commented out, causing the program not to perform as expected.
- Added necessary error checks to handle potential issues during directory copying and execution.
