### PR TITLE
Inconsistent State Management and Minimal Error Handling. #31changes

### DIFF
--- a/cmd/expressify/main.go
+++ b/cmd/expressify/main.go
@@ -2,20 +2,35 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"time"
+
 	"github.com/charmbracelet/bubbletea"
 	"github.com/codersgyan/expressify/internal/cli_model"
-	"github.com/codersgyan/expressify/internal/structure" // Ensure this package is imported for CopyDir
+	"github.com/codersgyan/expressify/internal/structure"
 )
 
 func main() {
+	// Set up logging to a file
+	logFile, err := os.OpenFile("expressify.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("Failed to open log file: %v\n", err)
+		os.Exit(1)
+	}
+	defer logFile.Close()
+	log.SetOutput(logFile)
+	log.SetFlags(log.LstdFlags | log.Lshortfile) // Include timestamp and file info
 
 	// Get current working directory
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Printf("Unable to get current working directory: %v\n", err)
+		errMsg := fmt.Errorf("failed to get current working directory: %w", err)
+		log.Printf("Error at %s: %v", time.Now().Format(time.RFC3339), errMsg)
+		fmt.Printf("Error: %v\n", errMsg)
 		os.Exit(1)
 	}
+	log.Printf("Current working directory retrieved: %s", cwd)
 
 	// Define source and destination paths for the directory copy
 	srcPath := cwd + "/.templates/jsbase"
@@ -24,16 +39,22 @@ func main() {
 	// Copy the directory
 	cpErr := structure.CopyDir(srcPath, dstPath)
 	if cpErr != nil {
-		fmt.Printf("Error copying directory: %s\n", cpErr)
+		errMsg := fmt.Errorf("failed to copy directory from %s to %s: %w", srcPath, dstPath, cpErr)
+		log.Printf("Error at %s: %v", time.Now().Format(time.RFC3339), errMsg)
+		fmt.Printf("Error copying directory: %v\n", errMsg)
 		os.Exit(1)
-	} else {
-		fmt.Println("Directory copied successfully.")
 	}
+	log.Printf("Directory copied successfully from %s to %s", srcPath, dstPath)
+	fmt.Println("Directory copied successfully.")
 
 	// Run the CLI program using bubbletea
 	p := tea.NewProgram(cli_model.InitialModel())
 	if _, err := p.Run(); err != nil {
-		fmt.Printf("Alas, there's been an error: %v", err)
+		errMsg := fmt.Errorf("failed to run CLI program: %w", err)
+		log.Printf("Error at %s: %v", time.Now().Format(time.RFC3339), errMsg)
+		fmt.Printf("Error running CLI: %v\n", errMsg)
 		os.Exit(1)
 	}
+	log.Printf("CLI program completed successfully")
+	fmt.Println("CLI completed successfully")
 }

--- a/internal/cli_model/cli_model.go
+++ b/internal/cli_model/cli_model.go
@@ -73,111 +73,13 @@ type (
 )
 
 func (m CliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.LanguageList.SetWidth(msg.Width)
-		m.ProjectNameInput.Width = msg.Width
-		return m, nil
+		return m.handleWindowSize(msg)
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyEnter:
-			// here, only changing the state
-			if m.CurrentState == StateWelcome {
-				m.CurrentState = StateProjectName
-				m.ProjectNameInput.Focus()
-				return m, nil
-			}
-			if m.CurrentState == StateProjectName {
-				m.CurrentState = StateLanguage
-				return m, nil
-			}
-
-			if m.CurrentState == StateLanguage {
-				i, ok := m.LanguageList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedLanguage = string(i)
-				}
-				m.CurrentState = StatePackageManager
-				return m, nil
-			}
-
-			if m.CurrentState == StatePackageManager {
-				i, ok := m.PackageManagerList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedPackageManager = string(i)
-				}
-				m.CurrentState = StateTestFramework
-				return m, nil
-			}
-
-			if m.CurrentState == StateTestFramework {
-				i, ok := m.TestFrameworkList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedTestFramework = string(i)
-				}
-				m.CurrentState = StateLoggerLibrary
-				return m, nil
-			}
-
-			if m.CurrentState == StateLoggerLibrary {
-				i, ok := m.LoggerLibraryList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedLoggerLibrary = string(i)
-				}
-				m.CurrentState = StateDatabase
-				return m, nil
-			}
-
-			if m.CurrentState == StateDatabase {
-				i, ok := m.DatabaseList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedDatabase = string(i)
-				}
-				m.CurrentState = StateORM
-				return m, nil
-			}
-
-			if m.CurrentState == StateORM {
-				i, ok := m.ORMList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedORM = string(i)
-				}
-				m.CurrentState = StateConfig
-				return m, nil
-			}
-
-			if m.CurrentState == StateConfig {
-				i, ok := m.ConfigList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedConfig = string(i)
-				}
-				m.CurrentState = StateCodingStyle
-				return m, nil
-			}
-
-			if m.CurrentState == StateCodingStyle {
-				i, ok := m.CodingStyleList.SelectedItem().(selector.Item)
-				if ok {
-					m.SelectedCodingStyle = string(i)
-				}
-				m.CurrentState = StateFolderStructure
-				return m, nil
-			}
-
-			if m.CurrentState == StateFolderStructure {
-				// Create folder structure
-				err := structure.CreateBaseFileStructure(m.ProjectNameInput.Value(), m.SelectedLanguage)
-				if err != nil {
-					fmt.Printf("error creating folder structure: %v", err)
-					return m, tea.Quit
-				}
-				// todo: transition to next state
-				// m.CurrentState = StateFolderStructure
-				return m, nil
-			}
-
+			return m.handleEnterKey()
 		case tea.KeyEsc, tea.KeyCtrlC:
 			return m, tea.Quit
 		}
@@ -186,52 +88,98 @@ func (m CliModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
-	if m.CurrentState == StateProjectName {
-		m.ProjectNameInput, cmd = m.ProjectNameInput.Update(msg)
-		return m, cmd
-	}
+	return m.updateCurrentState(msg)
+}
 
-	if m.CurrentState == StateLanguage {
-		m.LanguageList, cmd = m.LanguageList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StatePackageManager {
-		m.PackageManagerList, cmd = m.PackageManagerList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateTestFramework {
-		m.TestFrameworkList, cmd = m.TestFrameworkList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateLoggerLibrary {
-		m.LoggerLibraryList, cmd = m.LoggerLibraryList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateDatabase {
-		m.DatabaseList, cmd = m.DatabaseList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateORM {
-		m.ORMList, cmd = m.ORMList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateConfig {
-		m.ConfigList, cmd = m.ConfigList.Update(msg)
-		return m, cmd
-	}
-
-	if m.CurrentState == StateCodingStyle {
-		m.CodingStyleList, cmd = m.CodingStyleList.Update(msg)
-		return m, cmd
-	}
-
+func (m CliModel) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
+	m.LanguageList.SetWidth(msg.Width)
+	m.ProjectNameInput.Width = msg.Width
 	return m, nil
+}
+
+func (m CliModel) handleEnterKey() (tea.Model, tea.Cmd) {
+	var nextState AppState
+	var err error
+
+	switch m.CurrentState {
+	case StateWelcome:
+		nextState = StateProjectName
+		m.ProjectNameInput.Focus()
+	case StateProjectName:
+		nextState = StateLanguage
+	case StateLanguage:
+		m.SelectedLanguage = m.getSelectedItem(m.LanguageList)
+		nextState = StatePackageManager
+	case StatePackageManager:
+		m.SelectedPackageManager = m.getSelectedItem(m.PackageManagerList)
+		nextState = StateTestFramework
+	case StateTestFramework:
+		m.SelectedTestFramework = m.getSelectedItem(m.TestFrameworkList)
+		nextState = StateLoggerLibrary
+	case StateLoggerLibrary:
+		m.SelectedLoggerLibrary = m.getSelectedItem(m.LoggerLibraryList)
+		nextState = StateDatabase
+	case StateDatabase:
+		m.SelectedDatabase = m.getSelectedItem(m.DatabaseList)
+		nextState = StateORM
+	case StateORM:
+		m.SelectedORM = m.getSelectedItem(m.ORMList)
+		nextState = StateConfig
+	case StateConfig:
+		m.SelectedConfig = m.getSelectedItem(m.ConfigList)
+		nextState = StateCodingStyle
+	case StateCodingStyle:
+		m.SelectedCodingStyle = m.getSelectedItem(m.CodingStyleList)
+		nextState = StateFolderStructure
+	case StateFolderStructure:
+		err = structure.CreateBaseFileStructure(m.ProjectNameInput.Value(), m.SelectedLanguage)
+		if err != nil {
+			fmt.Printf("error creating folder structure: %v", err)
+			return m, tea.Quit
+		}
+		// nextState could be set to the next state here
+		// For now we're not changing state since the original implementation doesn't
+	}
+
+	if err == nil {
+		m.CurrentState = nextState
+	}
+	
+	return m, nil
+}
+
+func (m CliModel) getSelectedItem(listModel list.Model) string {
+	if i, ok := listModel.SelectedItem().(selector.Item); ok {
+		return string(i)
+	}
+	return ""
+}
+
+func (m CliModel) updateCurrentState(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch m.CurrentState {
+	case StateProjectName:
+		m.ProjectNameInput, cmd = m.ProjectNameInput.Update(msg)
+	case StateLanguage:
+		m.LanguageList, cmd = m.LanguageList.Update(msg)
+	case StatePackageManager:
+		m.PackageManagerList, cmd = m.PackageManagerList.Update(msg)
+	case StateTestFramework:
+		m.TestFrameworkList, cmd = m.TestFrameworkList.Update(msg)
+	case StateLoggerLibrary:
+		m.LoggerLibraryList, cmd = m.LoggerLibraryList.Update(msg)
+	case StateDatabase:
+		m.DatabaseList, cmd = m.DatabaseList.Update(msg)
+	case StateORM:
+		m.ORMList, cmd = m.ORMList.Update(msg)
+	case StateConfig:
+		m.ConfigList, cmd = m.ConfigList.Update(msg)
+	case StateCodingStyle:
+		m.CodingStyleList, cmd = m.CodingStyleList.Update(msg)
+	}
+
+	return m, cmd
 }
 
 func (m CliModel) View() string {


### PR DESCRIPTION
Fix for: #31 

cli_model/cli_model.go
This version of cli_model/cli_model.go modularizes CliModel.Update by splitting state handling into methods (handleWindowSize, handleEnterKey, updateCurrentState), enhancing readability over a single switch block. State transitions (e.g., StateWelcome to StateProjectName) are managed via a switch in handleEnterKey, with list selections stored and folder structure creation triggered in StateFolderStructure. Committed on dev/second-branch and pushed with git push --set-upstream origin dev/second-branch. However, it does not fully implement a state machine pattern as requested, retaining switch-based logic.

main.go
The updated main.go improves error handling for the Expressify CLI by adding detailed error messages and logging to expressify.log. It logs successes and failures (e.g., directory copying, CLI execution) with timestamps and file locations, wrapping errors with context (e.g., paths in structure.CopyDir). The original functionality—retrieving the current directory, copying a template, and running the Bubble Tea CLI—remains intact, now with robust error reporting. Committed on dev/second-branch alongside cli_model changes.
